### PR TITLE
Separate USER_JOINS_ROOM socket to CHOOSE_ROOM and ENTER_ROOM

### DIFF
--- a/src/client/screens/Login/ChooseRoom.tsx
+++ b/src/client/screens/Login/ChooseRoom.tsx
@@ -46,6 +46,8 @@ export default function ChooseRoom(props: Props): JSX.Element {
     if(!checkTextLength(roomName)) setRoomNameError('Name must be 1-15 symbols');
     else {
       updateUserContext({ username, room: roomName });
+      if (!socket) throw Error('No socket');
+      socket.emit(SOCKETS.CHOOSE_ROOM, { username, roomName });
       username && roomName && navigation.push('Playground', { username, room: roomName });
     }
   };

--- a/src/client/screens/Playground/index.tsx
+++ b/src/client/screens/Playground/index.tsx
@@ -22,7 +22,7 @@ export default function Playground(): JSX.Element {
   const { userContext } = useContext(UserContext);
   console.log('Playground, User context:', userContext);
 
-  
+
   // TODO: delete Playground routes everywhere
   // const route = useRoute<RouteProp<RootStackParamList, 'Playground'>>();
   // const { params } = route;
@@ -36,11 +36,12 @@ export default function Playground(): JSX.Element {
 
   useKeyEvent({ setBlock, setMatrix, setIsPause });
 
-  console.log(player); // TODO: use player.isLeader to show/hide tetris buttons
+  console.log('FETCH_CURRENT_PLAYER', player); // TODO: use player.isLeader to show/hide tetris buttons
 
   useEffect(() => {
     if (!socket) throw Error('No socket');
-    socket.emit(SOCKETS.USER_JOINS_ROOM, { username, roomName: room });
+    if (userContext.username && userContext.room) // If not solo mode, enter room
+      socket.emit(SOCKETS.ENTER_ROOM, { username, roomName: room });
 
     // Message from server
     socket.on(SOCKETS.CHAT_MESSAGE, (message: Message) => {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,7 +4,8 @@ export const SOCKETS = {
   FETCH_CURRENT_PLAYER: 'fetch current player',
 
   /* ---- Room ---- */
-  USER_JOINS_ROOM: 'join room',
+  CHOOSE_ROOM: 'create or join room',
+  ENTER_ROOM: 'enter room',
   UPDATE_ROOM_PLAYERS: 'update room players',
   
   /* ---- Game ---- */

--- a/src/server/controllers/Socket.ts
+++ b/src/server/controllers/Socket.ts
@@ -25,11 +25,7 @@ const connectSocketIO = (): void => {
       new Player({ id: socket.id, username });
     });
 
-    // TODO: separate USER_JOINS_ROOM, CHAT_MESSAGE and FETCH_CURRENT_PLAYER to different `socket.on` events
-    // TODO: on front move USER_JOINS_ROOM from Playground component to ChooseRoom component (on Play button click)
-    socket.on(SOCKETS.USER_JOINS_ROOM, ({ username, roomName }: { username: string, roomName: string }) => {
-      const player = Player.getByUsername(username);
-  
+    socket.on(SOCKETS.CHOOSE_ROOM, ({ username, roomName }: { username: string, roomName: string }) => {
       // Fetch room if it exists or create if it doesn't exist
       let room = Room.getByName(roomName);
       if (!room) {
@@ -37,30 +33,41 @@ const connectSocketIO = (): void => {
         const roomNames = Game.getWaitingRoomNames();
         socket.broadcast.emit(SOCKETS.UPDATE_WAITING_ROOMS, roomNames);
       }
-  
+
+      // Add player to current room
+      const player = Player.getByUsername(username);
       if (player) {
-        // Add player to current room
         room.addPlayer(player);
-  
         console.log('On join room: ', players);
-  
+      }
+    });
+
+    // TODO: separate CHOOSE_ROOM and ENTER_ROOM to different `socket.on` events
+    // On front move socket that creates room from Playground component to ChooseRoom component (on Play button click)
+    // Before, when we created room on Playground load, we created empty room when in solo mode: [ Room { players: [], name: undefined, gameStarted: false } ]
+    // Now it's fixed. Delete comment if clear @rizky
+    socket.on(SOCKETS.ENTER_ROOM, ({ username, roomName }: { username: string, roomName: string }) => {
+      const player = Player.getByUsername(username);
+      const room = Room.getByName(roomName);
+
+      if (player && room) {
         socket.join(room.name);
         console.log(`Socket ${socket.id} joined ${room.name}`);
-  
-        // Welcome current player
+
+        // Welcome current player in chat
         socket.emit(SOCKETS.CHAT_MESSAGE, formatMessage(botName, `Hi ${player.username}! Welcome to Room ${room.name}!`));
-  
-        // Send current player info
+
+        // Send current player info to Playground
         socket.emit(SOCKETS.FETCH_CURRENT_PLAYER, player);
-  
-        // Broadcast when a player connects
+
+        // Broadcast chat message when a player connects
         socket.broadcast
           .to(room.name)
           .emit(
             SOCKETS.CHAT_MESSAGE,
             formatMessage(botName, `${player.username} has joined the chat`),
           );
-  
+
         // Send players and room info when new player joins
         io.to(room.name).emit(SOCKETS.UPDATE_ROOM_PLAYERS, {
           room: room.name,
@@ -68,18 +75,18 @@ const connectSocketIO = (): void => {
         });
       }
     });
-  
-    // Listen for chatMessage
+
+    // Listen to chat message and send it to the room
     socket.on(SOCKETS.CHAT_MESSAGE, ({ username, message, room }: { username: string, message: string, room: string }) => {
       io.to(room).emit(SOCKETS.CHAT_MESSAGE, formatMessage(username, message));
     });
-  
+
     // Fetch all waiting rooms to Login screen
     socket.on(SOCKETS.FETCH_WAITING_ROOMS, () => {
       const roomNames = Game.getWaitingRoomNames();
-      socket.emit(SOCKETS.FETCH_WAITING_ROOMS, roomNames); // `on` and `emit` can have the same socket name
+      socket.emit(SOCKETS.FETCH_WAITING_ROOMS, roomNames);
     });
-  
+
     // Runs when client disconnects
     socket.on('disconnect', () => {
       const player = Player.getById(socket.id);
@@ -90,16 +97,16 @@ const connectSocketIO = (): void => {
         } else {
           room.removePlayer(player.id);
           console.log('On leave room: ', players, room.players);
-  
+
           if (room.players.length === 0) {
             // TODO: only makes sence if game has not been started and room was deleted.
-            // If started game was finished we don't care about waiting rooms - 
+            // If started game was finished we don't care about waiting rooms -
             // room with started game should be deleted from waiting room before, somewhere else
             Game.removeRoom(room.name);
             const roomNames = Game.getWaitingRoomNames();
             socket.broadcast.emit(SOCKETS.UPDATE_WAITING_ROOMS, roomNames);
           }
-  
+
           io.to(room.name).emit(
             SOCKETS.CHAT_MESSAGE,
             formatMessage(botName, `${player.username} has left the game`),


### PR DESCRIPTION
Since I moved socket creation to navigation and SocketContext, we used to create empty room when we play solo mode, like `['room1', null, 'room2']`

So I needed to stop creating empty data like. Now when I enter solo mode, I don't connect to CHOOSE_ROOM or ENTER_ROOM socket + 2 actions are separated.

// P.S. For the moment we automatically transfer to solo mode now if we reload the Playground page as socket recreates and UserContext clears